### PR TITLE
feat: return no layout when no session and redirect to / when sign out

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -9,10 +9,27 @@ import {
   useUser,
   useSupabaseClient,
   Session,
+  useSession,
 } from "@supabase/auth-helpers-react";
+import { useRouter } from "next/router";
 
 export default function Layout({ children }: any) {
+  const router = useRouter();
+  const session = useSession();
   const supabase = useSupabaseClient<Database>();
+
+  async function handleSignOut() {
+    // Terminate the session with Supabase
+    await supabase.auth.signOut();
+
+    // Redirect to /
+    router.push("/");
+  }
+
+  // We want to return empty Layout when no session is set, i.e. when in login page
+  if (!session) return <>{children}</>;
+
+  // Return the Layout if the session is set
   return (
     <AppShell
       padding="md"
@@ -81,10 +98,7 @@ export default function Layout({ children }: any) {
               </div>
             </Box>
           }
-          <Button
-            className="button block"
-            onClick={() => supabase.auth.signOut()}
-          >
+          <Button className="button block" onClick={handleSignOut}>
             Sign Out
           </Button>
         </Navbar>


### PR DESCRIPTION
El siguiente código realiza dos tareas importantes:

1. El componente de Layout no se muestra cuando no existe una sesión en el sistema.
2. Cuando se tiene una sesión y se hace clic en el botón de cerrar sesión, el componente de Layout redirecciona al login.

**Nota**: la implementación actual no cuida que el usuario pueda ingresar la URL de una página directamente aunque no haya iniciado sesión ya que no estamos utilizando **rutas o páginas protegidas**. Por el momento podemos seguir trabajando de esta manera, aunque no sería correcto que en producción (en una aplicación abierta a todo el público) exista este problema.